### PR TITLE
Add 42 since it works there too

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
     "settings-schema": "org.gnome.shell.extensions.desktop-cube",
     "shell-version": [
         "40",
-        "41"
+        "41",
+        "42"
     ],
     "url": "https://github.com/Schneegans/Desktop-Cube",
     "version": 8


### PR DESCRIPTION
Tested on Ubuntu Jammy + GNOME PPA with gnome-shell 42~alpha.

Preferences works too.

Thanks for this nice and useful extension.