### PR TITLE
:beetle: Do not obstruct GNOME Shell hot corners

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -652,7 +652,7 @@ class Extension {
         display: global.display,
         x1: 0,
         x2: 0,
-        y1: 0,
+        y1: 1,
         y2: global.stage.height,
         directions: Meta.BarrierDirection.POSITIVE_X,
       });
@@ -661,7 +661,7 @@ class Extension {
         display: global.display,
         x1: global.stage.width,
         x2: global.stage.width,
-        y1: 0,
+        y1: 1,
         y2: global.stage.height,
         directions: Meta.BarrierDirection.NEGATIVE_X,
       });


### PR DESCRIPTION
GNOME Shell defines a default pressure barrier for its hot corner at the top left (top right if on RTL locale). The current edge-drag workspace-switches barriers obstruct those, causing the hor corner not to work properly (requiring more pressure than with the extension disabled).

Fix this by repositioning the edge-drag workspace-switches barriers to not overlap with the hot corners.