### PR TITLE
Add scroll wrap-around and hide dash in overview

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,16 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Changelog of the Desktop Cube Extension
 
+## Unreleased
+
+#### Enhancements
+
+- Added a **scroll wrap-around** option in the Desktop preferences. When enabled, scrolling past the last workspace jumps to the first, and vice versa. This works by monkey-patching `Meta.Workspace.get_neighbor()` to return the opposite boundary workspace when GNOME would otherwise return the current one (GNOME returns `this` instead of `null` at boundaries). The full cube animation plays normally since `_prepareWorkspaceSwitch` is already patched by the extension.
+
+#### Bug Fixes
+
+- Fixed a crash when **Dash to Dock** (or similar extensions) is installed alongside Desktop Cube. The crash occurred because Dash to Dock removes the native GNOME Shell dash from the overview, causing `Main.overview._overview._controls._dash` to be `undefined`. Desktop Cube's "Hide Dash in Overview" feature now uses optional chaining (`?.`) to safely skip dash hiding/showing when the native dash is absent, instead of throwing a `TypeError`. This also fixes the same crash during extension disable while the screen is locked.
+
 ## [Desktop Cube 33](https://github.com/schneegans/Desktop-Cube/releases/tag/v33)
 
 **Release Date:** 2026-06-28

--- a/extension.js
+++ b/extension.js
@@ -462,6 +462,19 @@ export default class DesktopCube extends Extension {
       extensionThis._origEndGesture.apply(this, [time, distance, isTouchpad]);
     };
 
+    // Add scroll wrap-around.
+    if (this._settings.get_boolean('enable-scroll-wrap')) {
+      this._addScrollWrap();
+    }
+
+    this._settings.connect('changed::enable-scroll-wrap', () => {
+      if (this._settings.get_boolean('enable-scroll-wrap')) {
+        this._addScrollWrap();
+      } else {
+        this._removeScrollWrap();
+      }
+    });
+
     // Add single-click drag gesture to the desktop.
     if (this._settings.get_boolean('enable-desktop-dragging')) {
       this._addDesktopDragGesture();
@@ -559,6 +572,35 @@ export default class DesktopCube extends Extension {
           }
         });
 
+
+    // -----------------------------------------------------------------------------------
+    // ---------------------------- hide dash in overview --------------------------------
+    // -----------------------------------------------------------------------------------
+
+    const updateDashVisibility = () => {
+      const hide = this._settings.get_boolean('hide-dash-in-overview');
+      const dash = Main.overview._overview._controls._dash;
+      if (!dash) {
+        return;
+      }
+      if (hide && Main.overview.visible) {
+        dash.hide();
+      } else {
+        dash.show();
+      }
+    };
+
+    this._overviewShowingDashID = Main.overview.connect('showing', () => {
+      if (this._settings.get_boolean('hide-dash-in-overview')) {
+        Main.overview._overview._controls._dash?.hide();
+      }
+    });
+
+    this._overviewHidingDashID = Main.overview.connect('hiding', () => {
+      Main.overview._overview._controls._dash?.show();
+    });
+
+    this._settings.connect('changed::hide-dash-in-overview', updateDashVisibility);
 
     // -----------------------------------------------------------------------------------
     // ----------------------- enable edge-drag workspace-switches -----------------------
@@ -762,6 +804,9 @@ export default class DesktopCube extends Extension {
     WorkspaceAnimationController.prototype._prepareWorkspaceSwitch = this._origPrepSwitch;
     WorkspaceAnimationController.prototype._finishWorkspaceSwitch = this._origFinalSwitch;
 
+    // Remove scroll wrap-around.
+    this._removeScrollWrap();
+
     // Remove all drag-to-rotate gestures.
     this._removeDesktopDragGesture();
     this._removePanelDragGesture();
@@ -772,6 +817,10 @@ export default class DesktopCube extends Extension {
       this._skybox.destroy();
       this._skybox = null;
     }
+
+    Main.overview.disconnect(this._overviewShowingDashID);
+    Main.overview.disconnect(this._overviewHidingDashID);
+    Main.overview._overview._controls._dash?.show();
 
     Main.overview._overview.controls._workspaceAdjustment.disconnect(
       this._workspaceAdjustmentID);
@@ -1230,6 +1279,49 @@ export default class DesktopCube extends Extension {
   _removeDragGesture(info) {
     info.gesture.destroy();
     info.tracker.disconnect(info.trackerConnection);
+  }
+
+  // Intercepts scroll events on the background before GNOME processes them. When the
+  // user scrolls past the last (or first) workspace, we activate the first (or last)
+  // workspace directly, bypassing GNOME's linear clamp. The cube animation fires
+  // automatically because _prepareWorkspaceSwitch is already monkey-patched above.
+  // Monkey-patches Meta.Workspace.get_neighbor() so that navigating past the last or
+  // first workspace wraps around instead of returning null. GNOME's own workspace-switch
+  // code (keybindings, scroll) calls get_neighbor() to decide where to go, so patching
+  // here means the full animation plays normally — we never need to call activate().
+  _addScrollWrap() {
+    const wm = global.workspace_manager;
+
+    this._origGetNeighbor = wm.get_active_workspace().__proto__.get_neighbor;
+    const extensionThis   = this;
+
+    wm.get_active_workspace().__proto__.get_neighbor = function(direction) {
+      const result = extensionThis._origGetNeighbor.call(this, direction);
+
+      // GNOME returns the same workspace when at the boundary instead of null.
+      // Detect that case and wrap around manually.
+      if (result === this) {
+        const n = wm.get_n_workspaces();
+        if (direction == Meta.MotionDirection.RIGHT ||
+            direction == Meta.MotionDirection.DOWN) {
+          return wm.get_workspace_by_index(0);
+        }
+        if (direction == Meta.MotionDirection.LEFT ||
+            direction == Meta.MotionDirection.UP) {
+          return wm.get_workspace_by_index(n - 1);
+        }
+      }
+
+      return result;
+    };
+  }
+
+  _removeScrollWrap() {
+    if (this._origGetNeighbor) {
+      global.workspace_manager.get_active_workspace().__proto__.get_neighbor =
+        this._origGetNeighbor;
+      delete this._origGetNeighbor;
+    }
   }
 
   // Calls _addDragGesture() for the SwipeTracker and actor responsible for

--- a/prefs.js
+++ b/prefs.js
@@ -64,7 +64,9 @@ export default class DesktopCubePreferences extends ExtensionPreferences {
     this._bindSwitch('enable-desktop-dragging');
     this._bindSwitch('enable-panel-dragging');
     this._bindSwitch('enable-desktop-edge-switch');
+    this._bindSwitch('enable-scroll-wrap');
     this._bindSwitch('enable-overview-edge-switch');
+    this._bindSwitch('hide-dash-in-overview');
     this._bindSwitch('enable-overview-dragging');
     this._bindSwitch('do-explode');
     this._bindSwitch('per-monitor-perspective');

--- a/resources/ui/settings.ui
+++ b/resources/ui/settings.ui
@@ -343,6 +343,28 @@ SPDX-License-Identifier: GPL-3.0-or-later
           </object>
         </child>
 
+        <child>
+          <object class="AdwActionRow">
+            <property name="title" translatable="yes">Wrap around when scrolling past the last or first workspace</property>
+            <property name="activatable-widget">enable-scroll-wrap</property>
+            <child>
+              <object class="GtkSwitch" id="enable-scroll-wrap">
+                <property name="valign">center</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton" id="reset-enable-scroll-wrap">
+                <property name="icon-name">edit-clear-symbolic</property>
+                <property name="valign">center</property>
+                <property name="tooltip-text" translatable="yes">Reset to default value</property>
+                <style>
+                  <class name="flat" />
+                </style>
+              </object>
+            </child>
+          </object>
+        </child>
+
       </object>
     </child>
 
@@ -356,6 +378,28 @@ SPDX-License-Identifier: GPL-3.0-or-later
       <object class="AdwPreferencesGroup">
         <property name="title" translatable="yes">Overview Options</property>
         <property name="description" translatable="yes">These options tweak the cube in the overview.</property>
+
+        <child>
+          <object class="AdwActionRow">
+            <property name="title" translatable="yes">Hide the dash in the overview</property>
+            <property name="activatable-widget">hide-dash-in-overview</property>
+            <child>
+              <object class="GtkSwitch" id="hide-dash-in-overview">
+                <property name="valign">center</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton" id="reset-hide-dash-in-overview">
+                <property name="icon-name">edit-clear-symbolic</property>
+                <property name="valign">center</property>
+                <property name="tooltip-text" translatable="yes">Reset to default value</property>
+                <style>
+                  <class name="flat" />
+                </style>
+              </object>
+            </child>
+          </object>
+        </child>
 
         <child>
           <object class="AdwActionRow">

--- a/schemas/org.gnome.shell.extensions.desktop-cube.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.desktop-cube.gschema.xml
@@ -77,9 +77,21 @@ SPDX-License-Identifier: CC0-1.0
       <description>Switch workspaces when dragging a window over the desktop's edge.</description>
     </key>
 
+    <key name="enable-scroll-wrap" type="b">
+      <default>false</default>
+      <summary>Enable Scroll Wrap-Around</summary>
+      <description>Allow scrolling from the last workspace to the first and vice versa.</description>
+    </key>
+
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
     <!-- overview cube settings                                                        -->
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <key name="hide-dash-in-overview" type="b">
+      <default>false</default>
+      <summary>Hide Dash in Overview</summary>
+      <description>Hide the application dash when the overview is shown.</description>
+    </key>
 
     <key name="enable-overview-dragging" type="b">
       <default>true</default>


### PR DESCRIPTION
- Monkey-patch Meta.Workspace.get_neighbor() to wrap around when scrolling past the last or first workspace instead of blocking at boundaries.
- Add option to hide the native dash in the overview.
- Fix crash when Dash to Dock (or similar) is installed: use optional chaining on _dash accesses since Dash to Dock removes the native dash.